### PR TITLE
Fix bugs with LDAP value trimming

### DIFF
--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/update_ldap_entry_attributes.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/update_ldap_entry_attributes.rb
@@ -126,18 +126,18 @@ begin
       # All values get added individually instead of multiple entries to the same :add operation.
       if ldap_attribute_values.kind_of?(Array) && ldap_attribute_values.size > 1
         ldap_attribute_values.each do |value|
-          value = value.trim if value.is_a?(String)
+          value = value.strip if value.is_a?(String)
           ldap_attribute_operations.push([:add, ldap_attribute, value])
         end
       else
-        ldap_attribute_values = ldap_attribute_values.trim if value.is_a?(String)
+        ldap_attribute_values = ldap_attribute_values.strip if ldap_attribute_values.is_a?(String)
         ldap_attribute_operations.push([:add, ldap_attribute, ldap_attribute_values])
       end
     elsif ldap_attribute_values == ldap_entry[ldap_attribute]
       # do nothing since existing and new value are already equal
       $evm.log(:info, "No op for LDAP entry attribute (#{ldap_attribute}) since existing value already equals new value.") if @DEBUG
     elsif !ldap_attribute_values.blank? && !ldap_entry[ldap_attribute].blank?
-      ldap_attribute_values = ldap_attribute_values.trim if value.is_a?(String)
+      ldap_attribute_values = ldap_attribute_values.strip if ldap_attribute_values.is_a?(String)
       ldap_attribute_operations.push([:replace, ldap_attribute, ldap_attribute_values])
     else
       error("Could not calculate LDAP operation for LDAP entry attribute (#{ldap_attribute}). This should never happen.")


### PR DESCRIPTION
This PR fixes an earlier one, modifying update_ldap_entry_attributes to trim leading/trailing spaces from values before they are sent to LDAP.