### PR TITLE
add_ldap_entry retry if newly created record is not visible immediately

### DIFF
--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__class__.yaml
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__class__.yaml
@@ -29,5 +29,5 @@ object:
       on_entry: 
       on_exit: 
       on_error: 
-      max_retries: 
-      max_time: '120'
+      max_retries: '10'
+      max_time: ''

--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/add_ldap_entry.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/add_ldap_entry.rb
@@ -165,7 +165,7 @@ begin
         #If no entry is found, this probably means we're waiting on LDAP replication. Retry and check again.
         $evm.set_state_var(:retry_method, true)
         $evm.log(:info, "New LDAP entry not found. Retrying in 60 seconds.")
-        automate_retry(60, "Waiting for replication between LDAP servers")
+        automate_retry(30, "Waiting for replication between LDAP servers")
       end
     else
       error("Unable to add LDAP entry for #{ldap_new_entry_dn}.  LDAP Error = #{ldap.get_operation_result.to_s}")

--- a/Automate/RedHatConsulting_LDAP/__domain__.yaml
+++ b/Automate/RedHatConsulting_LDAP/__domain__.yaml
@@ -7,6 +7,8 @@ object:
     description: ManageIQ Automate Domain for reading and writing information from
       and to LDAP.
     display_name: LDAP
+    priority: 5
     enabled: true
+    tenant_id: 1000000000001
     source: user
     top_level_namespace: 


### PR DESCRIPTION
Often, in environments with 2 LDAP servers behind a load balancer, newly created records are not mirrored between the two backing servers before we query to confirm that they were created. This pull request changes that behavior, causing it to check back every 30 seconds until it finds the new record or hits a timeout.