### PR TITLE
update to store LDAP entries as Hashes rather then Net:LDAP objects to prevent issues with marshaling and unmarshaling the objects

### DIFF
--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/DynamicDialogs.class/__methods__/get_ldap_entries.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/DynamicDialogs.class/__methods__/get_ldap_entries.rb
@@ -9,9 +9,6 @@
 #
 @DEBUG = false
 
-require 'rubygems'
-require 'net/ldap'
-
 # Log an error and exit.
 #
 # @param msg Message to error with
@@ -59,6 +56,7 @@ begin
   
   # get the parameters
   ldap_entries = get_param(:ldap_entries)
+  $evm.log(:info, "ldap_entries => #{ldap_entries}") if @DEBUG
   
   values = {}
   if ldap_entries
@@ -68,9 +66,9 @@ begin
     dialog_description_ldap_entry_attribute_name = get_param(:dialog_description_ldap_entry_attribute_name) || dialog_value_ldap_entry_attribute_name
   
     values = {}
-    ldap_entries.each do |entry|
-      value       = entry[dialog_value_ldap_entry_attribute_name][0]
-      description = entry[dialog_description_ldap_entry_attribute_name][0]
+    ldap_entries.each do |ldap_entry|
+      value         = ldap_entry[dialog_value_ldap_entry_attribute_name.to_sym][0]
+      description   = ldap_entry[dialog_description_ldap_entry_attribute_name.to_sym][0]
       values[value] = description
     end
     $evm.log(:info, "values => #{values}") if @DEBUG
@@ -83,4 +81,6 @@ begin
   dialog_field["data_type"]  = "string"
   dialog_field["required"]   = true
   dialog_field["values"]     = values
+  
+  $evm.log(:info, "dialog_field['values'] => #{dialog_field['values']}") if @DEBUG
 end

--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/Operations/Methods.class/__methods__/get_vm_tags_and_attributes_from_ldap_entry.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/Operations/Methods.class/__methods__/get_vm_tags_and_attributes_from_ldap_entry.rb
@@ -7,9 +7,6 @@
 #   EVM STATE || EVM CURRENT || EVM OBJECT || EVM ROOT || $evm.root['miq_provision']
 #     vm - set to VM to get LDAP entries for
 #
-#   EVM STATE || EVM CURRENT || EVM OBJECT || EVM ROOT
-#     ldap_entries - LDAP entires to get the Tag Catigory(s) and Tag(s) for. 
-#
 # SETS
 #   EVM OBJECT
 #     :ldap_vm_tags - Hash of Tag Catigories to Tag(s) to assign to the given VM.

--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/delete_ldap_entries.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/delete_ldap_entries.rb
@@ -107,14 +107,14 @@ begin
     
     deletion_errors = []
     ldap_entries.each do |ldap_entry|
-      $evm.log(:info, "Delete LDAP entry: { :dn => #{ldap_entry.dn} }") if @DEBUG
-      delete_success = ldap.delete(:dn => ldap_entry.dn)
+      $evm.log(:info, "Delete LDAP entry: { :dn => #{ldap_entry[:dn]} }") if @DEBUG
+      delete_success = ldap.delete(:dn => ldap_entry[:dn])
       
       if delete_success
-        $evm.log(:info, "Successfully deleted LDAP entry: { :dn => #{ldap_entry.dn} }")
+        $evm.log(:info, "Successfully deleted LDAP entry: { :dn => #{ldap_entry[:dn]} }")
       else
         # collect errors
-        deletion_errors << "Failed to deleted LDAP entry: { :dn => #{ldap_entry.dn} }. This is typically either a permisisons issue. See LDAP server error logs for details."
+        deletion_errors << "Failed to deleted LDAP entry: { :dn => #{ldap_entry[:dn]} }. This is typically either a permisisons issue. See LDAP server error logs for details."
       end
     end
     

--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/get_ldap_entries.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/get_ldap_entries.rb
@@ -89,6 +89,30 @@ def get_param(param)
   return param_value
 end
 
+# Takes an Array of Net::LDAP objects and turns them into hashes so that they can
+# be marshaled and unmarshaled.
+#
+# @param ldap_entries Array of Net:LDAP objects to turn into an Array of Hashes
+#
+# @return Array of Hashes created from the given Array of Net::LDAP objects
+def ldap_entries_to_hashes(ldap_entries)
+  ldap_entries_hashes = []
+  ldap_entries.each do |ldap_entry|
+    ldap_entry_hash = {}
+    ldap_entry.each do |ldap_attribute, ldap_attribute_value|
+      if ldap_attribute_value.is_a? Array
+        ldap_entry_hash[ldap_attribute.to_sym] = ldap_attribute_value.collect { |value| value.to_s }
+      else
+        ldap_entry_hash[ldap_attribute.to_sym] = ldap_attribute_value.to_s
+      end
+    end
+
+    ldap_entries_hashes.push(ldap_entry_hash)
+  end
+
+  return ldap_entries_hashes
+end
+
 begin
   # determine the LDAP connection configuration information
   ldap_config = get_ldap_config()
@@ -146,7 +170,7 @@ begin
     # if found LDAP entries
     # else error
     if ldap_entries.size > 0
-      $evm.object['ldap_entries'] = ldap_entries
+      $evm.object['ldap_entries'] = ldap_entries_to_hashes(ldap_entries)
       $evm.log(:info, "ldap_entries => #{ldap_entries}")
     else
       error("LDAP could not find any entries for #{ldap_filter_attribute}=#{ldap_filter_value}")

--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/get_vm_tags_and_attributes_from_ldap_entries.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/get_vm_tags_and_attributes_from_ldap_entries.rb
@@ -102,9 +102,9 @@ begin
   # Collect all of the Tags and Custom Attributes to apply to the VM
   ldap_vm_tags = {}
   ldap_vm_custom_attributes = {}
-  ldap_entries.each do |entry|
+  ldap_entries.each do |ldap_entry|
     # get the VM Tags and Attributes for the given VM and LDAP entry
-    entry_ldap_vm_tags, entry_ldap_vm_custom_attributes = get_vm_tags_and_attributes_from_ldap_entry(vm, entry)
+    entry_ldap_vm_tags, entry_ldap_vm_custom_attributes = get_vm_tags_and_attributes_from_ldap_entry(vm, ldap_entry)
     $evm.log(:info, "entry_ldap_vm_tags=#{entry_ldap_vm_tags}")                           if @DEBUG
     $evm.log(:info, "entry_ldap_vm_custom_attributes=#{entry_ldap_vm_custom_attributes}") if @DEBUG
     


### PR DESCRIPTION
This breaks API because previously the get_ldap_entries and add_ldap_entries methods returned an array of Net::LDAP objects and now it returns an Array of Hash objects to deal with marshaling and un-marshaling issues.