### PR TITLE
Do not store keys as symbols

### DIFF
--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/get_vm_tags_and_attributes_from_ldap_entries.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/get_vm_tags_and_attributes_from_ldap_entries.rb
@@ -73,15 +73,15 @@ def get_vm_tags_and_attributes_from_ldap_entry(vm, ldap_entry)
   $evm.log(:info, "{ vm => '#{vm.name}', ldap_entry='#{ldap_entry}'") if @DEBUG
   
   # set params
-  $evm.root[:vm]         = vm
-  $evm.root[:ldap_entry] = ldap_entry
+  $evm.root['vm']         = vm
+  $evm.root['ldap_entry'] = ldap_entry
   
   # call method
   result = $evm.instantiate("#{GET_VM_TAGS_FROM_LDAP_ENTRY_URI}")
   
   # clean up params
-  $evm.root[:vm]         = nil
-  $evm.root[:ldap_entry] = nil
+  $evm.root['vm']         = nil
+  $evm.root['ldap_entry'] = nil
   
   # return result
   return result[:ldap_vm_tags], result[:ldap_vm_custom_attributes]

--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/validate_ldap_email_addresses.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/validate_ldap_email_addresses.rb
@@ -142,9 +142,9 @@ def validate_ldap_entry_exists_for_ldap_attribute_value(ldap_treebase, ldap_filt
     $evm.log(:info, "ldap_filter_value => #{ldap_filter_value}") if @DEBUG
  
     # set instantiate paramaters
-    $evm.root[:ldap_treebase]         = ldap_treebase
-    $evm.root[:ldap_filter_attribute] = ldap_filter_attribute
-    $evm.root[:ldap_filter_value]     = ldap_filter_value
+    $evm.root['ldap_treebase']         = ldap_treebase
+    $evm.root['ldap_filter_attribute'] = ldap_filter_attribute
+    $evm.root['ldap_filter_value']     = ldap_filter_value
 
     # instantiate
     begin
@@ -154,9 +154,9 @@ def validate_ldap_entry_exists_for_ldap_attribute_value(ldap_treebase, ldap_filt
       $evm.root['ae_result']            = nil
       $evm.root['ae_reason']            = nil
  
-      $evm.root[:ldap_treebase]         = nil
-      $evm.root[:ldap_filter_attribute] = nil
-      $evm.root[:ldap_filter_value]     = nil
+      $evm.root['ldap_treebase']         = nil
+      $evm.root['ldap_filter_attribute'] = nil
+      $evm.root['ldap_filter_value']     = nil
     end
 
     # get results


### PR DESCRIPTION
- It is not supported to store keys as symbols in the root hash
- get_param method looks for both symbols and strings, making this change transparent