### PR TITLE
Updated set_ldap_sync_status.rb to use underscores instead of spaces …

### DIFF
--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/set_ldap_sync_status.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/set_ldap_sync_status.rb
@@ -13,8 +13,8 @@
 @DEBUG = false
 
 TAG_CATIGORY_LDAP_SYNC_SUCCESSFUL = "LDAP Sync Successful"
-ATTRIBUTE_LAST_LDAP_SYNC          = "Last LDAP Sync Attempt"
-ATTRIBUTE_LDAP_SYNC_STATUS        = "LDAP Sync Status"
+ATTRIBUTE_LAST_LDAP_SYNC          = "Last_LDAP_Sync_Attempt"
+ATTRIBUTE_LDAP_SYNC_STATUS        = "LDAP_Sync_Status"
 DEFAULT_LDAP_SYNC_STAUTS          = "Unknown"
 DEFAULT_LDAP_SYNC_SUCCESSFUL      = false
 


### PR DESCRIPTION
…as custom attributes are not searchable with spaces.

Committer: Curtis L. Matthews <curt@redhat.com>

On branch curt-matthews_custom_attr
Changes to be committed:
modified:   Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/set_ldap_sync_status.rb