### PR TITLE
During cleanup, do not overwrite $evm.root['vm'] with nil

### DIFF
--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/get_vm_tags_and_attributes_from_ldap_entries.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/get_vm_tags_and_attributes_from_ldap_entries.rb
@@ -71,7 +71,9 @@ end
 #         ldap_vm_custom_attributes VM Custom Attributes to apply based on the given LDAP entry
 def get_vm_tags_and_attributes_from_ldap_entry(vm, ldap_entry)
   $evm.log(:info, "{ vm => '#{vm.name}', ldap_entry='#{ldap_entry}'") if @DEBUG
-  
+
+  saved_vm = $evm.root['vm']
+
   # set params
   $evm.root['vm']         = vm
   $evm.root['ldap_entry'] = ldap_entry
@@ -80,9 +82,9 @@ def get_vm_tags_and_attributes_from_ldap_entry(vm, ldap_entry)
   result = $evm.instantiate("#{GET_VM_TAGS_FROM_LDAP_ENTRY_URI}")
   
   # clean up params
-  $evm.root['vm']         = nil
+  $evm.root['vm']         = saved_vm
   $evm.root['ldap_entry'] = nil
-  
+
   # return result
   return result[:ldap_vm_tags], result[:ldap_vm_custom_attributes]
 end

--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/update_ldap_entry_attributes_for_batch_of_vms.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/update_ldap_entry_attributes_for_batch_of_vms.rb
@@ -77,7 +77,9 @@ end
 #         false if there was any error in the state machine to update the LDAP entry attributes
 def update_ldap_entry_attributes(vm, options)
   $evm.log(:info, "START: Update LDAP entry attributes for { vm => #{vm.name} }") if @DEBUG
-  
+
+  saved_vm = $evm.root['vm']
+
   begin
     # instantiate the state machine to update a single VM
     $evm.root['vm']      = vm
@@ -92,7 +94,7 @@ def update_ldap_entry_attributes(vm, options)
     $evm.root['ae_result']    = nil
     $evm.root['ae_reason']    = nil
     
-    $evm.root['vm']           = nil
+    $evm.root['vm']           = saved_vm
     $evm.root['options']      = nil
     $evm.root['ldap_entries'] = nil
   end

--- a/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/update_tags_and_custom_attributes_from_ldap_entries_for_batch_of_vms.rb
+++ b/Automate/RedHatConsulting_LDAP/Integration/LDAP/StateMachines/Methods.class/__methods__/update_tags_and_custom_attributes_from_ldap_entries_for_batch_of_vms.rb
@@ -62,6 +62,8 @@ end
 #         false if there was any error in the state machine to update the Tags and Custom Attributes for the given VM
 def update_vm_tags_and_custom_attributes_from_ldap_entries(vm)
   $evm.log(:info, "START: Update VM Tags and Custom Attributes based on LDAP records for { vm => #{vm.name} }") if @DEBUG
+
+  saved_vm = $evm.root['vm']
   
   begin
     # instantiate the state machine to update a single VM
@@ -76,7 +78,7 @@ def update_vm_tags_and_custom_attributes_from_ldap_entries(vm)
     $evm.root['ae_result']            = nil
     $evm.root['ae_reason']            = nil
     
-    $evm.root['vm']                   = nil
+    $evm.root['vm']                   = saved_vm
     $evm.root['ldap_entries']         = nil
     $evm.root['ldap_sync_status']     = nil
     $evm.root['ldap_sync_successful'] = nil


### PR DESCRIPTION
+ Cache old state of $evm.root['vm'], and restore to that